### PR TITLE
Old "strict mode" replaced by configurable attributes

### DIFF
--- a/demos/templates/ngx.ui.addressInput.html
+++ b/demos/templates/ngx.ui.addressInput.html
@@ -1,13 +1,27 @@
 <fieldset>
 	<legend>Example using Seznam maps API</legend>
-	<form name="form_address">
-		<label>Address with house number:</label>
-		<input type="text" name="address" ng-model="address" ngx-address-input data-geomap="#map_canvas" />
-		<img id="address_spinner" ng-show="form_address.address.loading" src="http://www.jobs.cz/images/preloader.gif"/>
-		<div ngx-invalid="form_address.address found_number">
+    <p>
+        Allowed types (parts): firm, city, street, number
+    </p>
+    <p>
+        Required types (parts): city, street
+    </p>
+    <form name="form_address">
+		<label>Address:</label>
+		<input type="text" name="address" ng-model="address" ngx-address-input data-geomap="#map_canvas" required-types="city,street" allowed-types="firm,city,street,number" />
+        <img id="address_spinner" ng-show="form_address.address.loading" src="http://www.jobs.cz/images/preloader.gif"/>
+		<div ngx-invalid="form_address.address found">
 			Address not found
 		</div>
+        <div ngx-invalid="form_address.address street">
+            Street must be defined
+        </div>
+        <div ngx-invalid="form_address.address city">
+            City must be defined
+        </div>
+
 	</form>
+
 	<div ngx-geomap id="map_canvas" style="width: 500px; height: 250px"></div>
 </fieldset>
 <pre ng-show="address">{{address|json}}</pre>

--- a/src/modules/ui/addressInput/addressInput.js
+++ b/src/modules/ui/addressInput/addressInput.js
@@ -14,8 +14,10 @@
                 var hasGeomap = angular.isDefined(attrs.geomap);
 
                 return function(scope, element, attrs, ctrl) {
-                    var strict,      // is strict? .. require address by street number
-                        geomap;
+                    var geomap;
+
+                    var allowedTypes = attrs.allowedTypes ? attrs.allowedTypes.replace(/[ ]+/g, '').split(',') : [];
+                    var requiredTypes = attrs.requiredTypes ? attrs.requiredTypes.replace(/[ ]+/g, '').split(',') : [];
 
                     // parse input value and set into model
                     ctrl.$parsers.push(function(data) {
@@ -31,14 +33,9 @@
 
                             element.val(data.label);
                         } else if (angular.isString(data) || angular.isUndefined(data)) {
-                            model = (strict ? undefined : { label: data });
+                            model = { label: data };
                         } else {
                             throw 'Invalid address data';
-                        }
-
-                        // valid by address number
-                        if (strict) {
-                            ctrl.$setValidity('number', model && model.number ? true : false);
                         }
 
                         return model;
@@ -56,41 +53,8 @@
                         }
                     });
 
-                    function setStrictMode(value) {
-                        if (strict === value) {
-                            return;
-                        }
-
-                        strict = value;
-
-                        // update validation state
-                        ctrl.$setValidity('number', !strict);
-                        found(true);
-
-                        // close possible opened autocomplete
-                        element.autocomplete('close');
-
-                        // force search when non-strict mode
-                        if (!strict) {
-                            $timeout(function() {
-                                element.autocomplete('search');
-                            }, 0);
-                        }
-                    }
-
-                    function found(count, byNumber) {
+                    function found(count) {
                         ctrl.$setValidity('found', angular.isNumber(count) ? (count > 0) : count);
-                        ctrl.$setValidity('found_number', angular.isDefined(byNumber) ? (angular.isNumber(byNumber) ? (byNumber > 0) : byNumber) : count);
-                    }
-
-                    // strict mode by default
-                    setStrictMode(true);
-
-                    // watch strict flag attribute expression
-                    if (attrs.strict) {
-                        scope.$watch(attrs.strict, function(value) {
-                            setStrictMode(value);
-                        });
                     }
 
                     ctrl.loading = false;
@@ -132,6 +96,10 @@
 
                             loading(false);
                             found(true);
+
+                            angular.forEach(requiredTypes, function (requiredType) {
+                                ctrl.$setValidity(requiredType, data && data[requiredType] ? true : false);
+                            });
                         });
                     }
 
@@ -154,28 +122,16 @@
 
                             geomap.geocodeQuery(request.term, function(results) {
                                 var $results = [];
-                                var foundCount = results.length;
 
                                 angular.forEach(results, function(item) {
-                                    // ignore addresses without number in strict mode
-                                    if (strict && item.type !== 'number') {
-                                        return;
-                                    }
 
-                                    // ignore ČR in strict mode .. @hack
-                                    if (!strict && item.label.match(/Česká republika/)) {
-                                        return;
-                                    }
-
-                                    // allow only these address types
-                                    if (item.type === 'street' || item.type === 'city' || item.type === 'number' || item.type === 'country') {
+                                    // allow only address types defined in attribute
+                                    if (!allowedTypes.length || allowedTypes.indexOf(item.type) > -1) {
                                         $results.push(item);
                                     }
                                 });
 
-                                if (strict) {
-                                    found(foundCount, $results.length);
-                                }
+                                found($results.length);
 
                                 response($results);
                                 loading(false);

--- a/src/ngx.js
+++ b/src/ngx.js
@@ -1,4 +1,4 @@
-(function(angular) {
+(function(angular, Array) {
     'use strict';
 
     angular.module('ngx', [
@@ -30,4 +30,16 @@
         'ngx.ui.wysiwyg'
     ]);
 
-})(window.angular);
+    // missing ECMAScript functions
+    if (!Array.prototype.indexOf) {
+        Array.prototype.indexOf = function(search) {
+            for (var i = 0; i < this.length; i++) {
+                if (this[i] === search) {
+                    return i;
+                }
+            }
+            return -1;
+        };
+    }
+
+})(window.angular, Array);


### PR DESCRIPTION
Added attributes: 

allowed-types - allows you to accept allowed types of result only. Empty value = all types are allowed (backward compatibility).

required-types - allows you to define required list of types. Empty values = no types are required. This attribute replaces old "strict mode".

Example: allowed-types="firm,city,street,number" required-types="street,city"
Only "firm, city, street or number" types of result will be accepted and both street and city parts must be defined in chosen result.
