### PR TITLE
removed font-size from imageupload style - fixed bug in Firefox and IE

### DIFF
--- a/src/modules/ui/imageupload/imageupload.less
+++ b/src/modules/ui/imageupload/imageupload.less
@@ -59,7 +59,6 @@
 			right: 0;
 			top: 0;
 			z-index: 1;
-			font-size: 460px;
 			margin: 0;
 			padding: 0;
 			cursor: pointer;


### PR DESCRIPTION
![chybi-button](https://f.cloud.github.com/assets/156132/1067531/2b24584c-13d2-11e3-8a13-61cde092a0be.jpg)
